### PR TITLE
feat: add getUserGroups method to list Zendesk groups of the instance

### DIFF
--- a/src/zendesk/choices.ts
+++ b/src/zendesk/choices.ts
@@ -25,7 +25,8 @@ export enum ZendeskUserUrls {
   Groups = '/api/v2/users/{userId}/groups.json',
   Tags = '/api/v2/users/{userId}/tags.json',
   Identities = '/api/v2/users/{userId}/identities.json',
-  Identity = '/api/v2/users/{userId}/identities/{identityId}.json'
+  Identity = '/api/v2/users/{userId}/identities/{identityId}.json',
+  UserGroups = '/api/v2/groups.json'
 }
 
 export enum Methods {

--- a/src/zendesk/users.ts
+++ b/src/zendesk/users.ts
@@ -70,4 +70,11 @@ export class ZendeskUsersClient extends ZendeskClient {
       pathParams: { userId }
     });
   }
+
+  async getUserGroups() {
+    return this.makeRequest({
+      url: ZendeskUserUrls.UserGroups,
+      method: Methods.GET
+    });
+  }
 }

--- a/tests/zendesk/users.test.ts
+++ b/tests/zendesk/users.test.ts
@@ -81,4 +81,12 @@ describe('ZendeskUsersClient', () => {
       pathParams: { userId: '1' }
     });
   });
+
+  it('should call makeRequest with the correct params to getUserGroups', () => {
+    zendeskUsersClient.getUserGroups();
+    expect(zendeskUsersClient.makeRequest).toHaveBeenCalledWith({
+      url: ZendeskUserUrls.UserGroups,
+      method: Methods.GET
+    });
+  });
 });


### PR DESCRIPTION
**Description:**
_Introduce the getUserGroups method to list groups within the Zendesk instance_

**Type of change:**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Why is this change required?:**
_So the user of the lib can list Zendesk groups easily_

---

**Checklist:**

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
