### PR TITLE
fix: default content type and JSON stringify

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,13 +25,6 @@ jobs:
         with:
           node-version: 18.x
 
-      - name: Setup SSH Keys and known_hosts
-        run: |
-          mkdir -p ~/.ssh
-          ssh-keyscan github.com >> ~/.ssh/known_hosts
-          ssh-agent -a $SSH_AUTH_SOCK > /dev/null
-          ssh-add - <<< "${{ secrets.SSH_PRIVATE_KEY }}"
-
       - name: Install Node Modules
         run: npm ci
 

--- a/src/zendesk/choices.ts
+++ b/src/zendesk/choices.ts
@@ -35,3 +35,7 @@ export enum Methods {
   PUT = 'PUT',
   DELETE = 'DELETE'
 }
+
+export enum ContentType {
+  JSON = 'application/json'
+}

--- a/src/zendesk/tickets.ts
+++ b/src/zendesk/tickets.ts
@@ -1,7 +1,7 @@
 import { ZendeskClient } from '@coaktion/client-core';
 import { ClientOptionsZendesk } from '@coaktion/client-core/dist/types';
 
-import { Methods, ZendeskTicketUrls } from './choices';
+import { ContentType, Methods, ZendeskTicketUrls } from './choices';
 
 export class ZendeskTicketsClient extends ZendeskClient {
   constructor(client: ClientOptionsZendesk) {
@@ -106,7 +106,8 @@ export class ZendeskTicketsClient extends ZendeskClient {
     return this.makeRequest({
       url: ZendeskTicketUrls.Tickets,
       method: Methods.POST,
-      data
+      data: JSON.stringify(data),
+      contentType: ContentType.JSON
     });
   }
 
@@ -115,7 +116,8 @@ export class ZendeskTicketsClient extends ZendeskClient {
       url: ZendeskTicketUrls.Comments,
       method: Methods.POST,
       pathParams: { ticketId },
-      data
+      data: JSON.stringify(data),
+      contentType: ContentType.JSON
     });
   }
 
@@ -124,7 +126,8 @@ export class ZendeskTicketsClient extends ZendeskClient {
       url: ZendeskTicketUrls.Collaborators,
       method: Methods.POST,
       pathParams: { ticketId },
-      data
+      data: JSON.stringify(data),
+      contentType: ContentType.JSON
     });
   }
 
@@ -132,7 +135,8 @@ export class ZendeskTicketsClient extends ZendeskClient {
     return this.makeRequest({
       url: ZendeskTicketUrls.TicketFields,
       method: Methods.POST,
-      data
+      data: JSON.stringify(data),
+      contentType: ContentType.JSON
     });
   }
 
@@ -141,7 +145,8 @@ export class ZendeskTicketsClient extends ZendeskClient {
       url: ZendeskTicketUrls.TicketFieldOptions,
       method: Methods.POST,
       pathParams: { ticketFieldId },
-      data
+      data: JSON.stringify(data),
+      contentType: ContentType.JSON
     });
   }
 
@@ -150,7 +155,8 @@ export class ZendeskTicketsClient extends ZendeskClient {
       url: ZendeskTicketUrls.Ticket,
       method: Methods.PUT,
       pathParams: { ticketId },
-      data
+      data: JSON.stringify(data),
+      contentType: ContentType.JSON
     });
   }
 
@@ -159,7 +165,8 @@ export class ZendeskTicketsClient extends ZendeskClient {
       url: ZendeskTicketUrls.TicketField,
       method: Methods.PUT,
       pathParams: { ticketFieldId },
-      data
+      data: JSON.stringify(data),
+      contentType: ContentType.JSON
     });
   }
 
@@ -168,7 +175,8 @@ export class ZendeskTicketsClient extends ZendeskClient {
       url: ZendeskTicketUrls.TicketFieldOptions,
       method: Methods.PUT,
       pathParams: { ticketFieldId },
-      data
+      data: JSON.stringify(data),
+      contentType: ContentType.JSON
     });
   }
 

--- a/tests/zendesk/tickets.test.ts
+++ b/tests/zendesk/tickets.test.ts
@@ -2,6 +2,7 @@ import { ClientOptionsZendesk } from '@coaktion/client-core/dist/types';
 
 import { Methods, ZendeskTicketUrls } from '../../src';
 import { ZendeskTicketsClient } from '../../src';
+import { ContentType } from '../../src/zendesk/choices';
 
 describe('ZendeskTicketsClient', () => {
   let zendeskTicketsClient: ZendeskTicketsClient;
@@ -122,7 +123,8 @@ describe('ZendeskTicketsClient', () => {
     expect(zendeskTicketsClient.makeRequest).toHaveBeenCalledWith({
       url: ZendeskTicketUrls.Tickets,
       method: Methods.POST,
-      data: {}
+      data: JSON.stringify({}),
+      contentType: ContentType.JSON
     });
   });
 
@@ -132,7 +134,8 @@ describe('ZendeskTicketsClient', () => {
       url: ZendeskTicketUrls.Comments,
       method: Methods.POST,
       pathParams: { ticketId: '1' },
-      data: {}
+      data: JSON.stringify({}),
+      contentType: ContentType.JSON
     });
   });
 
@@ -142,7 +145,8 @@ describe('ZendeskTicketsClient', () => {
       url: ZendeskTicketUrls.Collaborators,
       method: Methods.POST,
       pathParams: { ticketId: '1' },
-      data: {}
+      data: JSON.stringify({}),
+      contentType: ContentType.JSON
     });
   });
 
@@ -151,7 +155,8 @@ describe('ZendeskTicketsClient', () => {
     expect(zendeskTicketsClient.makeRequest).toHaveBeenCalledWith({
       url: ZendeskTicketUrls.TicketFields,
       method: Methods.POST,
-      data: {}
+      data: JSON.stringify({}),
+      contentType: ContentType.JSON
     });
   });
 
@@ -161,7 +166,8 @@ describe('ZendeskTicketsClient', () => {
       url: ZendeskTicketUrls.TicketFieldOptions,
       method: Methods.POST,
       pathParams: { ticketFieldId: '1' },
-      data: {}
+      data: JSON.stringify({}),
+      contentType: ContentType.JSON
     });
   });
 
@@ -171,7 +177,8 @@ describe('ZendeskTicketsClient', () => {
       url: ZendeskTicketUrls.Ticket,
       method: Methods.PUT,
       pathParams: { ticketId: '1' },
-      data: {}
+      data: JSON.stringify({}),
+      contentType: ContentType.JSON
     });
   });
 
@@ -181,7 +188,8 @@ describe('ZendeskTicketsClient', () => {
       url: ZendeskTicketUrls.TicketField,
       method: Methods.PUT,
       pathParams: { ticketFieldId: '1' },
-      data: {}
+      data: JSON.stringify({}),
+      contentType: ContentType.JSON
     });
   });
 
@@ -191,7 +199,8 @@ describe('ZendeskTicketsClient', () => {
       url: ZendeskTicketUrls.TicketFieldOptions,
       method: Methods.PUT,
       pathParams: { ticketFieldId: '1' },
-      data: {}
+      data: JSON.stringify({}),
+      contentType: ContentType.JSON
     });
   });
 


### PR DESCRIPTION
Resolves #NUMBER

**Description:**
 Setting content type and JSON.stringfy as default options to zendesk POST and PUT requests. that uses data on body.
**Type of change:**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Why is this change required?:**
_A simple explanation of what the problem is and how this PR solves it_

**Code changes:**

- _A bullet point list of key code changes that have been made._
- _When describing code changes, try to communicate **how** and **why** you implemented something a specific way, not just **what** has changed._

---

**Checklist:**

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
